### PR TITLE
Fix type error

### DIFF
--- a/rados/striper.go
+++ b/rados/striper.go
@@ -58,7 +58,7 @@ func (sp *StriperPool) State(oid string) (uint64,uint64, error) {
 func (sp *StriperPool) Truncate(oid string, offset uint64) error{
     c_oid := C.CString(oid)
     defer C.free(unsafe.Pointer(c_oid))
-	ret := C.rados_striper_trunc(sp.ioctx, c_oid, C.uint64_t(offset))
+	ret := C.rados_striper_trunc(sp.striper, c_oid, C.uint64_t(offset))
 	if ret < 0 {
 		return RadosError(int(ret))
 	}


### PR DESCRIPTION
Build error on Ubuntu:
```
../go/pkg/mod/github.com/journeymidnight/radoshttpd@v0.0.0-20190617133011-609666b51136/rados/striper.go:61:159: cannot use _cgo0 (type _Ctype_rados_ioctx_t) as type _Ctype_rados_striper_t in argument to _Cfunc_rados_striper_trunc
```
Upstream changed function signature: https://github.com/ceph/ceph/pull/20301/commits/417720f2b4155bc07b8fc16e6d0dfdf67976cbbf